### PR TITLE
Create /bin directory automatically

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -1,0 +1,3 @@
+# Autotune /bin directory
+
+This directory is for storing uploaded map files. It should be system writable and exist for the plugin to function properly.


### PR DESCRIPTION
Historically we had to manually create the /bin directory for the plugin to work